### PR TITLE
Fix checkpoints leakage issues in GRPO training

### DIFF
--- a/fastvideo/train_grpo_sd.py
+++ b/fastvideo/train_grpo_sd.py
@@ -476,7 +476,7 @@ def main(_):
 
             latents = torch.stack(latents, dim=1).detach().clone()     # (4, num_steps+1, ...)
             log_probs = torch.stack(log_probs, dim=1).detach().clone()   # (4, num_steps, ...)
-            rewards = torch.cat(rewards, dim=0).clone()  
+            rewards = torch.cat(rewards, dim=0).detach()
             
 
             all_latents.append(latents)
@@ -543,7 +543,7 @@ def main(_):
             group_rewards = samples["rewards"][start_idx:end_idx]
             group_mean = group_rewards.mean()
             group_std = group_rewards.std() + 1e-8
-            advantages[start_idx:end_idx] = (group_rewards - group_mean) / group_std
+            advantages[start_idx:end_idx] = ((group_rewards - group_mean) / group_std).detach()
         samples["advantages"] = advantages.clone()
 
         samples["final_advantages"] = advantages.clone()

--- a/fastvideo/train_grpo_sd.py
+++ b/fastvideo/train_grpo_sd.py
@@ -474,9 +474,9 @@ def main(_):
                                 hps_score = hps_score[:,0]
                             rewards.append(hps_score)
 
-            latents = torch.stack(latents, dim=1).detach()     # (4, num_steps+1, ...)
-            log_probs = torch.stack(log_probs, dim=1).detach()   # (4, num_steps, ...)
-            rewards = torch.cat(rewards, dim=0)  
+            latents = torch.stack(latents, dim=1).detach().clone()     # (4, num_steps+1, ...)
+            log_probs = torch.stack(log_probs, dim=1).detach().clone()   # (4, num_steps, ...)
+            rewards = torch.cat(rewards, dim=0).clone()  
             
 
             all_latents.append(latents)
@@ -544,9 +544,9 @@ def main(_):
             group_mean = group_rewards.mean()
             group_std = group_rewards.std() + 1e-8
             advantages[start_idx:end_idx] = (group_rewards - group_mean) / group_std
-        samples["advantages"] = advantages
+        samples["advantages"] = advantages.clone()
 
-        samples["final_advantages"] = advantages
+        samples["final_advantages"] = advantages.clone()
         
 
         total_batch_size, num_timesteps = samples["timesteps"].shape


### PR DESCRIPTION
When I am rerunning the same GRPO training, I am seeing improved performance. This is due to the residual gradients or cached tensors influencing the optimization, creating a form of "momentum" that wasn't intended. This is why we see improvement without explicit changes.

## Fix Leakage in SD-GRPO Training

### Problem
The training process had gradient leakage issues causing non-reproducible results and unintended optimization behavior.

### Changes
1. **Fix detach calls**
   - Added `.detach().clone()` to latents and log_probs stacking
   - Added `.detach()` to rewards concatenation

2. Fix advantages calculation
   - Added `.detach()` to normalized advantages
   - Ensured advantages tensors are properly cloned

3. **Always clone input latents**
   - Added `.clone()` to input_latents to prevent gradient accumulation

### Why This Matters
- Eliminates gradient leakage from previous training runs
- Ensures reproducible training results
- Prevents overfitting to gradient artifacts
- Makes debugging and optimization transparent